### PR TITLE
fix: avoid generating invalid destination filename on macOS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,7 @@ function WriteTSFile(iTargetFileName: string, iPrefix: string | undefined, iSuff
 
     const justPath = path.dirname(iTargetFileName);
     const nameWithoutExtension = path.basename(iTargetFileName, path.extname(iTargetFileName));
-    const destinationFilename = path.join(".", justPath, `${iPrefix}${nameWithoutExtension}${iSuffix}.ts`);
+    const destinationFilename = path.join(justPath, `${iPrefix}${nameWithoutExtension}${iSuffix}.ts`)
     const baseValidatorPath = iPathToValidator === "runtime-typescript-checker" ? iPathToValidator : path.relative(path.dirname(iTargetFileName), iPathToValidator).split(path.sep).join(path.posix.sep);
 
     if (path.relative(iTargetFileName, destinationFilename) === "")


### PR DESCRIPTION
justPath is already an absolute path and joining an absolute path to "." on macOS causes an invalid relative path to be generated

e.g 
`path.join('.', '/Users/sergeim/the/path') == 'Users/sergeim/the/path'`